### PR TITLE
Potential fix for code scanning alert no. 10: Bad HTML filtering regexp

### DIFF
--- a/src/components/shared/SecureForm.tsx
+++ b/src/components/shared/SecureForm.tsx
@@ -57,16 +57,9 @@ const SecureForm: React.FC<SecureFormProps> = ({
       const sanitizedData = new FormData();
       for (const [key, value] of formData.entries()) {
         if (typeof value === 'string') {
-          // Basic XSS prevention - remove script tags and dangerous attributes
-          let sanitized = value;
-          let previous;
-          do {
-            previous = sanitized;
-            sanitized = sanitized
-              .replace(/<script\b[^<]*(?:(?!<\/script>)<[^<]*)*<\/script>/gi, '')
-              .replace(/javascript:/gi, '')
-              .replace(/on\w+\s*=/gi, '');
-          } while (sanitized !== previous);
+          // Use DOMPurify for robust XSS prevention
+          const DOMPurify = require('dompurify');
+          const sanitized = DOMPurify.sanitize(value, { ALLOWED_TAGS: [], ALLOWED_ATTR: [] });
           sanitizedData.append(key, sanitized);
         } else {
           sanitizedData.append(key, value);


### PR DESCRIPTION
Potential fix for [https://github.com/Jensinjames/marketing-spark-engine/security/code-scanning/10](https://github.com/Jensinjames/marketing-spark-engine/security/code-scanning/10)

To fix the issue, replace the custom regular expression-based sanitization logic with a well-tested HTML sanitization library, such as `DOMPurify`. This library is specifically designed to handle edge cases and ensure robust sanitization of HTML input. 

**Steps to fix:**
1. Install `DOMPurify` as a dependency.
2. Replace the iterative sanitization logic (lines 63–69) with a call to `DOMPurify.sanitize()`.
3. Ensure that `DOMPurify` is configured securely to remove dangerous content, such as scripts and event handlers.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
